### PR TITLE
Fix regex lists matching every url

### DIFF
--- a/background.js
+++ b/background.js
@@ -102,7 +102,7 @@
     function isListed(url) {
         let re;
         for (var i=0;i < list.length;i++) {
-            re = new RegExp(re);
+            re = new RegExp(list[i]);
             if(re.test(url)) {
                 log('debug', 'isListed: ' + url);
                 return true;


### PR DESCRIPTION
I'm not able to fully test this. Don't really know much about Javascript, and even less about Firefox extensions, but it appears like you're creating a RegExp with `undefined` as a constructor argument.

I tested to see what would happen and it seems to, strangely, match everything:
```js
let re;
var reg = new RegExp(re);
reg.test("lawjdlajwdlawd");
//> true 
```

Indeed if you try setting any regex, it will remove every tab from management (i.e. all tabs will be matched by the exclusion rule, because the actual rule isn't being read, the `RegExp(undefined)` is).

Likewise, setting manual mode on and having any url regex rule will add every tab to management.