### PR TITLE
Only manage mute state if audible or already muted

### DIFF
--- a/background.js
+++ b/background.js
@@ -118,11 +118,9 @@
     log("debug", "updateMuteState");
     let tabs = await browser.tabs.query({ active: true, currentWindow: true });
     const activTabId = tabs[0].id;
-    log("debug", "Querying tabs");
     tabs = (await browser.tabs.query({
       /*url: "<all_urls>"*/
     }));
-    log("debug", "Queryed tabs");
     tabs.forEach(async (tab) => {
       // ignore not https? urls
       if (!url_regex.test(tab.url)) {

--- a/background.js
+++ b/background.js
@@ -119,8 +119,9 @@
     let tabs = await browser.tabs.query({ active: true, currentWindow: true });
     const activTabId = tabs[0].id;
     log("debug", "Querying tabs");
-    tabs = (await browser.tabs.query({}))
-      .filter(t => t.audible || t.mutedInfo.muted);
+    tabs = (await browser.tabs.query({
+      /*url: "<all_urls>"*/
+    }));
     log("debug", "Queryed tabs");
     tabs.forEach(async (tab) => {
       // ignore not https? urls
@@ -148,7 +149,9 @@
         (mode && !_regexList && _taggedManually);
 
       if (managed) {
-        setMuted(tab.id, tab.id !== activTabId);
+        if (tab.audible || tab.mutedInfo.muted) {
+          setMuted(tab.id, tab.id !== activTabId);
+        }
         browser.browserAction.setBadgeText({ tabId: tab.id, text: "ON" });
         browser.browserAction.setBadgeBackgroundColor({
           tabId: tab.id,

--- a/background.js
+++ b/background.js
@@ -222,7 +222,10 @@
   browser.browserAction.onClicked.addListener(onClicked);
   browser.tabs.onRemoved.addListener(onRemoved);
   browser.tabs.onActivated.addListener(updateMuteState);
-  browser.tabs.onUpdated.addListener(updateMuteState);
+  const updateFilter = {
+    properties: ["audible", "mutedInfo"]
+  };
+  browser.tabs.onUpdated.addListener(updateMuteState, updateFilter);
   browser.windows.onFocusChanged.addListener(updateMuteState);
   browser.runtime.onInstalled.addListener(updateMuteState);
   browser.storage.onChanged.addListener(onStorageChange);

--- a/background.js
+++ b/background.js
@@ -118,9 +118,10 @@
     log("debug", "updateMuteState");
     let tabs = await browser.tabs.query({ active: true, currentWindow: true });
     const activTabId = tabs[0].id;
-    tabs = await browser.tabs.query({
-      /*url: "<all_urls>"*/
-    });
+    log("debug", "Querying tabs");
+    tabs = (await browser.tabs.query({}))
+      .filter(t => t.audible || t.mutedInfo.muted);
+    log("debug", "Queryed tabs");
     tabs.forEach(async (tab) => {
       // ignore not https? urls
       if (!url_regex.test(tab.url)) {
@@ -218,6 +219,7 @@
   browser.browserAction.onClicked.addListener(onClicked);
   browser.tabs.onRemoved.addListener(onRemoved);
   browser.tabs.onActivated.addListener(updateMuteState);
+  browser.tabs.onUpdated.addListener(updateMuteState);
   browser.windows.onFocusChanged.addListener(updateMuteState);
   browser.runtime.onInstalled.addListener(updateMuteState);
   browser.storage.onChanged.addListener(onStorageChange);


### PR DESCRIPTION
# Purpose
This attempts to reduce the number of immediate uninstalls for first time users.

It's quite jarring to install Mute Unfocused Tabs and suddenly have every tab given the `MUTED` tag. I think some users would see it as too invasive and reflexively uninstall the extension, despite it doing exactly what it says on the tin.

# Changelog
- Only sets mute state for tabs that are either audible or already muted
- Updates tab mute state on all tab updates. For example, if a tab becomes audible

# Details
Me again. Addressing this old issue: https://github.com/igorlogius/mute-unfocused-tabs/issues/3

I think it's a fair request. We have both the property to check for audible state and an event listener for when that property changes.

Here's a demo of it in action:

https://github.com/igorlogius/mute-unfocused-tabs/assets/13639947/66a27149-d71c-4d29-a6ed-be2210ceb8f9

# Gotchas
The `audible` state of a tab is overridden by its `muted` state. This means a couple of seconds after a tab is muted, it will have `audible == false` regardless of whether sound would play if we unmuted.

This means that if, for example, a song finishes in an unfocused, muted tab, `audible` won't change state. The tab will remain muted until another listener affects it (for example, the user focuses the tab).

I don't see this as an issue, just thought you should know.